### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/devops-project-kyoheim/7849c987-f2ac-47f9-ae8b-18bc75ebad49/aadee185-cd83-48a8-93dc-a6cdd0709dfa/_apis/work/boardbadge/1c47f10a-d98b-4d07-bea0-3d2fb81f6c77)](https://dev.azure.com/devops-project-kyoheim/7849c987-f2ac-47f9-ae8b-18bc75ebad49/_boards/board/t/aadee185-cd83-48a8-93dc-a6cdd0709dfa/Microsoft.RequirementCategory)
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/devops-project-kyoheim/7849c987-f2ac-47f9-ae8b-18bc75ebad49/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.